### PR TITLE
check for nil query string before appending

### DIFF
--- a/lib/redirector/middleware.rb
+++ b/lib/redirector/middleware.rb
@@ -93,7 +93,7 @@ module Redirector
           uri.scheme ||= request_scheme
           uri.host   ||= request_host
           uri.port   ||= request_port if request_port.present?
-          uri.query  ||= env['QUERY_STRING'] if Redirector.preserve_query
+          uri.query  ||= env['QUERY_STRING'] if Redirector.preserve_query && !env['QUERY_STRING'].nil?
         end
       end
 


### PR DESCRIPTION
Fixes an issue where a destination URL with no querystring will end in ?, which causes an additional unnecessary redirect.